### PR TITLE
Fixed to enable to use pydantic v2 package

### DIFF
--- a/mii/entrypoints/data_models.py
+++ b/mii/entrypoints/data_models.py
@@ -9,7 +9,8 @@ from typing import Literal, Optional, List, Dict, Any, Union
 import time
 
 import shortuuid
-from mii.pydantic_v1 import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 
 class ErrorResponse(BaseModel):

--- a/mii/entrypoints/openai_api_server.py
+++ b/mii/entrypoints/openai_api_server.py
@@ -52,7 +52,7 @@ from .data_models import (
 app = FastAPI()
 load_balancer = "localhost:50050"
 tokenizer = None
-app_settings = AppSettings()
+app_settings = None
 get_bearer_token = HTTPBearer(auto_error=False)
 
 
@@ -217,7 +217,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
             chunk = ChatCompletionStreamResponse(id=id,
                                                  choices=firstChoices,
                                                  model=app_settings.model_id)
-            yield f"data: {chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
+            yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
             async for response_chunk in stub.GeneratorReplyStream(requestData):
                 streamChoices = []
 
@@ -233,7 +233,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
                 chunk = ChatCompletionStreamResponse(id=id,
                                                      choices=streamChoices,
                                                      model=app_settings.model_id)
-                yield f"data: {chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
+                yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
             yield "data: [DONE]\n\n"
 
         return StreamingResponse(StreamResults(), media_type="text/event-stream")
@@ -352,7 +352,7 @@ async def create_completion(request: CompletionRequest):
                     choices=streamChoices,
                     model=app_settings.model_id,
                 )
-                yield f"data: {chunk.json(exclude_unset=True, ensure_ascii=False)}\n\n"
+                yield f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
             yield "data: [DONE]\n\n"
 
         return StreamingResponse(StreamResults(), media_type="text/event-stream")
@@ -471,6 +471,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    app_settings = AppSettings(model_id=args.model)
     # Set the deployment name
     if args.deployment_name is not None:
         app_settings.deployment_name = args.deployment_name


### PR DESCRIPTION
Previously DeepSpeed-MII used pydantic_v1 and fixed to use new pydantic packages.

I think it's related to issue #543

In addition, changed from the deprecated json() method to the model_json_dump() method.
For more details, please see below.
https://docs.pydantic.dev/latest/migration/

I performed the test in the following environment:

Ubuntu22.04
pydantic                 2.10.6
pydantic_core            2.27.2
pydantic-settings        2.7.1
deepspeed                0.16.3
deepspeed-kernels        0.0.1.dev1698255861
deepspeed-mii            0.3.1+fcd0a5b
